### PR TITLE
Initial customisations to WSCoachMarksView

### DIFF
--- a/WSCoachMarksView.h
+++ b/WSCoachMarksView.h
@@ -50,8 +50,6 @@
 @property (nonatomic) CGFloat cutoutRadius;
 @property (nonatomic) CGFloat maxLblWidth;
 @property (nonatomic) CGFloat lblSpacing;
-@property (nonatomic) BOOL enableContinueLabel;
-@property (nonatomic) BOOL enableSkipButton;
 
 - (id)initWithFrame:(CGRect)frame coachMarks:(NSArray *)marks;
 - (void)start;

--- a/WSCoachMarksView.h
+++ b/WSCoachMarksView.h
@@ -44,6 +44,7 @@
 
 @property (nonatomic, WS_WEAK) id<WSCoachMarksViewDelegate> delegate;
 @property (nonatomic, retain) NSArray *coachMarks;
+@property (nonatomic) NSUInteger markIndex;
 @property (nonatomic, retain) UILabel *lblCaption;
 @property (nonatomic, retain) UIColor *maskColor;
 @property (nonatomic) CGFloat animationDuration;
@@ -52,7 +53,7 @@
 @property (nonatomic) CGFloat lblSpacing;
 
 - (id)initWithFrame:(CGRect)frame coachMarks:(NSArray *)marks;
-- (void)start;
+- (void)startAtCoachMark:(NSUInteger)coachMarkIndex;
 
 @end
 

--- a/WSCoachMarksView.h
+++ b/WSCoachMarksView.h
@@ -53,6 +53,7 @@
 @property (nonatomic) CGFloat lblSpacing;
 
 - (id)initWithFrame:(CGRect)frame coachMarks:(NSArray *)marks;
+- (void)start;
 - (void)startAtCoachMark:(NSUInteger)coachMarkIndex;
 
 @end

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -307,40 +307,80 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     CGFloat continueLabelX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth - kButtonPadding;
     CGFloat buttonY = self.bounds.size.height - (2.0f * kShadowLayerOffset) - kButtonHeight;
     
+    // If the coach mark would overlap the navigation buttons, re-position the buttons to be above the coach mark
+    // (Including the caption, which is likely above the coach mark in this case)
+    if (CGRectGetMaxY(markRect) > buttonY)
+    {
+        buttonY = CGRectGetMinY(self.lblCaption.frame) - (2.0f * kShadowLayerOffset) - kButtonHeight;
+    }
+    
     // Back button
-    btnBack = [[UIButton alloc] initWithFrame:CGRectMake(backButtonX, buttonY, backButtonWidth, kButtonHeight)];
-    [btnBack addTarget:self action:@selector(goToPreviousCoachMark) forControlEvents:UIControlEventTouchUpInside];
-    [btnBack setTitle:@"Back" forState:UIControlStateNormal];
-    btnBack.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
-    btnBack.alpha = 0.0f;
-    [self addSubview:btnBack];
-    [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
-        btnBack.alpha = 1.0f;
-    } completion:nil];
+    CGRect backButtonFrame = CGRectMake(backButtonX, buttonY, backButtonWidth, kButtonHeight);
+    if (!btnBack)
+    {
+        btnBack = [[UIButton alloc] initWithFrame:backButtonFrame];
+        [btnBack addTarget:self action:@selector(goToPreviousCoachMark) forControlEvents:UIControlEventTouchUpInside];
+        [btnBack setTitle:@"Back" forState:UIControlStateNormal];
+        btnBack.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
+        btnBack.alpha = 0.0f;
+        [self addSubview:btnBack];
+        [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
+            btnBack.alpha = 1.0f;
+        } completion:nil];
+    }
+    else
+    {
+        [UIView animateWithDuration:self.animationDuration
+                         animations:^{
+                             [btnBack setFrame:backButtonFrame];
+                         }];
+    }
     
     // Skip button
-    btnSkipCoach = [[UIButton alloc] initWithFrame:CGRectMake(skipButtonX, buttonY, skipButtonWidth, kButtonHeight)];
-    [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
-    [btnSkipCoach setTitle:@"Skip" forState:UIControlStateNormal];
-    btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
-    btnSkipCoach.alpha = 0.0f;
-    [btnSkipCoach setTitleColor:[UIColor lightGrayColor] forState:UIControlStateNormal];
-    [self addSubview:btnSkipCoach];
-    [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
-        btnSkipCoach.alpha = 1.0f;
-    } completion:nil];
+    CGRect skipButtonFrame = CGRectMake(skipButtonX, buttonY, skipButtonWidth, kButtonHeight);
+    if (!btnSkipCoach)
+    {
+        btnSkipCoach = [[UIButton alloc] initWithFrame:skipButtonFrame];
+        [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
+        [btnSkipCoach setTitle:@"Skip" forState:UIControlStateNormal];
+        btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
+        btnSkipCoach.alpha = 0.0f;
+        [btnSkipCoach setTitleColor:[UIColor lightGrayColor] forState:UIControlStateNormal];
+        [self addSubview:btnSkipCoach];
+        [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
+            btnSkipCoach.alpha = 1.0f;
+        } completion:nil];
+    }
+    else
+    {
+        [UIView animateWithDuration:self.animationDuration
+                         animations:^{
+                             [btnSkipCoach setFrame:skipButtonFrame];
+                         }];
+    }
     
     // Next label
-    lblContinue = [[UILabel alloc] initWithFrame:CGRectMake(continueLabelX, buttonY, continueLabelWidth, kButtonHeight)];
-    lblContinue.font = [UIFont boldSystemFontOfSize:15.0f];
-    lblContinue.textAlignment = NSTextAlignmentCenter;
-    lblContinue.text = @"Next";
-    lblContinue.alpha = 0.0f;
-    lblContinue.textColor = [UIColor whiteColor];
-    [self addSubview:lblContinue];
-    [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
-        lblContinue.alpha = 1.0f;
-    } completion:nil];
+    CGRect continueLabelFrame = CGRectMake(continueLabelX, buttonY, continueLabelWidth, kButtonHeight);
+    if (!lblContinue)
+    {
+        lblContinue = [[UILabel alloc] initWithFrame:continueLabelFrame];
+        lblContinue.font = [UIFont boldSystemFontOfSize:15.0f];
+        lblContinue.textAlignment = NSTextAlignmentCenter;
+        lblContinue.text = @"Next";
+        lblContinue.alpha = 0.0f;
+        lblContinue.textColor = [UIColor whiteColor];
+        [self addSubview:lblContinue];
+        [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
+            lblContinue.alpha = 1.0f;
+        } completion:nil];
+    }
+    else
+    {
+        [UIView animateWithDuration:self.animationDuration
+                         animations:^{
+                             [lblContinue setFrame:continueLabelFrame];
+                         }];
+    }
 }
 
 #pragma mark - Cleanup

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -13,7 +13,7 @@ static const CGFloat kAnimationDuration = 0.3f;
 static const CGFloat kCutoutRadius = 2.0f;
 static const CGFloat kMaxLblWidth = 300.0f;
 static const CGFloat kLblSpacing = 35.0f;
-static const CGFloat kButtonHeight = 30.0f;
+static const CGFloat kButtonHeight = 60.0f;
 static const CGFloat kShadowLayerOffset = 3.0f;
 
 @implementation WSCoachMarksView {
@@ -266,7 +266,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     btnBack = [[UIButton alloc] initWithFrame:(CGRect){{backButtonX, buttonY}, {backButtonWidth, kButtonHeight}}];
     [btnBack addTarget:self action:@selector(goToPreviousCoachMark) forControlEvents:UIControlEventTouchUpInside];
     [btnBack setTitle:@"Back" forState:UIControlStateNormal];
-    btnBack.titleLabel.font = [UIFont boldSystemFontOfSize:13.0f];
+    btnBack.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
     btnBack.alpha = 0.0f;
     [self addSubview:btnBack];
     [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
@@ -277,7 +277,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     btnSkipCoach = [[UIButton alloc] initWithFrame:(CGRect){{skipButtonX, buttonY}, {skipButtonWidth, kButtonHeight}}];
     [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
     [btnSkipCoach setTitle:@"Skip" forState:UIControlStateNormal];
-    btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:13.0f];
+    btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
     btnSkipCoach.alpha = 0.0f;
     [btnSkipCoach setTitleColor:[UIColor lightGrayColor] forState:UIControlStateNormal];
     [self addSubview:btnSkipCoach];
@@ -287,7 +287,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     
     // Next label
     lblContinue = [[UILabel alloc] initWithFrame:(CGRect){{continueLabelX, buttonY}, {continueLabelWidth,kButtonHeight}}];
-    lblContinue.font = [UIFont boldSystemFontOfSize:13.0f];
+    lblContinue.font = [UIFont boldSystemFontOfSize:15.0f];
     lblContinue.textAlignment = NSTextAlignmentCenter;
     lblContinue.text = @"Next";
     lblContinue.alpha = 0.0f;

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -14,6 +14,7 @@ static const CGFloat kCutoutRadius = 2.0f;
 static const CGFloat kMaxLblWidth = 300.0f;
 static const CGFloat kLblSpacing = 35.0f;
 static const CGFloat kButtonHeight = 60.0f;
+static const CGFloat kButtonPadding = 10.0f;
 static const CGFloat kShadowLayerOffset = 3.0f;
 
 @implementation WSCoachMarksView {
@@ -254,12 +255,12 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     // Animate the cutout
     [self animateCutoutToRect:markRect withShape:shape];
     
-    CGFloat backButtonWidth = (20.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
-    CGFloat skipButtonWidth = (20.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
-    CGFloat continueLabelWidth = (20.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
-    CGFloat backButtonX = 0.0f;
-    CGFloat skipButtonX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth - skipButtonWidth;
-    CGFloat continueLabelX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth;
+    CGFloat backButtonWidth = (16.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
+    CGFloat skipButtonWidth = (16.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
+    CGFloat continueLabelWidth = (16.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
+    CGFloat backButtonX = kButtonPadding;
+    CGFloat skipButtonX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth - skipButtonWidth - kButtonPadding;
+    CGFloat continueLabelX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth - kButtonPadding;
     CGFloat buttonY = self.bounds.size.height - (2.0f * kShadowLayerOffset) - kButtonHeight;
     
     // Back button

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -13,13 +13,13 @@ static const CGFloat kAnimationDuration = 0.3f;
 static const CGFloat kCutoutRadius = 2.0f;
 static const CGFloat kMaxLblWidth = 300.0f;
 static const CGFloat kLblSpacing = 35.0f;
+static const CGFloat kButtonHeight = 30.0f;
 static const CGFloat kShadowLayerOffset = 3.0f;
-static const BOOL kEnableContinueLabel = YES;
-static const BOOL kEnableSkipButton = YES;
 
 @implementation WSCoachMarksView {
     CAShapeLayer *mask;
     NSUInteger markIndex;
+    UIButton *btnBack;
     UILabel *lblContinue;
     UIButton *btnSkipCoach;
 }
@@ -34,8 +34,6 @@ static const BOOL kEnableSkipButton = YES;
 @synthesize cutoutRadius;
 @synthesize maxLblWidth;
 @synthesize lblSpacing;
-@synthesize enableContinueLabel;
-@synthesize enableSkipButton;
 
 #pragma mark - Methods
 
@@ -75,8 +73,6 @@ static const BOOL kEnableSkipButton = YES;
     self.cutoutRadius = kCutoutRadius;
     self.maxLblWidth = kMaxLblWidth;
     self.lblSpacing = kLblSpacing;
-    self.enableContinueLabel = kEnableContinueLabel;
-    self.enableSkipButton = kEnableSkipButton;
     
     // Shape layer mask
     mask = [CAShapeLayer layer];
@@ -194,6 +190,13 @@ static const BOOL kEnableSkipButton = YES;
                      }];
 }
 
+- (void)goToPreviousCoachMark {
+    // Go to the previous coach mark
+    if (markIndex > 0) {
+        [self goToCoachMarkIndexed:(markIndex-1)];
+    }
+}
+
 - (void)skipCoach {
     [self goToCoachMarkIndexed:self.coachMarks.count];
 }
@@ -251,41 +254,48 @@ static const BOOL kEnableSkipButton = YES;
     // Animate the cutout
     [self animateCutoutToRect:markRect withShape:shape];
     
-    CGFloat lblContinueWidth = self.enableSkipButton ? (70.0/100.0) * self.bounds.size.width - (2 * kShadowLayerOffset) : self.bounds.size.width - (2 * kShadowLayerOffset);
-    CGFloat btnSkipWidth = self.bounds.size.width - lblContinueWidth;
+    CGFloat backButtonWidth = (20.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
+    CGFloat skipButtonWidth = (20.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
+    CGFloat continueLabelWidth = (20.0f/100.0f) * self.bounds.size.width - (2 * kShadowLayerOffset);
+    CGFloat backButtonX = 0.0f;
+    CGFloat skipButtonX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth - skipButtonWidth;
+    CGFloat continueLabelX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth;
+    CGFloat buttonY = self.bounds.size.height - (2.0f * kShadowLayerOffset) - kButtonHeight;
     
-    // Show continue lbl if first mark
-    if (self.enableContinueLabel) {
-        if (markIndex == 0) {
-            lblContinue = [[UILabel alloc] initWithFrame:(CGRect){{0, self.bounds.size.height - (2 * kShadowLayerOffset) - 30.0f}, {lblContinueWidth, 30.0f}}];
-            lblContinue.font = [UIFont boldSystemFontOfSize:13.0f];
-            lblContinue.textAlignment = NSTextAlignmentCenter;
-            lblContinue.text = @"Tap to continue";
-            lblContinue.alpha = 0.0f;
-            lblContinue.backgroundColor = [UIColor whiteColor];
-            [self addSubview:lblContinue];
-            [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
-                lblContinue.alpha = 1.0f;
-            } completion:nil];
-        } else if (markIndex > 0 && lblContinue != nil) {
-            // Otherwise, remove the lbl
-            [lblContinue removeFromSuperview];
-            lblContinue = nil;
-        }
-    }
+    // Back button
+    btnBack = [[UIButton alloc] initWithFrame:(CGRect){{backButtonX, buttonY}, {backButtonWidth, kButtonHeight}}];
+    [btnBack addTarget:self action:@selector(goToPreviousCoachMark) forControlEvents:UIControlEventTouchUpInside];
+    [btnBack setTitle:@"Back" forState:UIControlStateNormal];
+    btnBack.titleLabel.font = [UIFont boldSystemFontOfSize:13.0f];
+    btnBack.alpha = 0.0f;
+    [self addSubview:btnBack];
+    [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
+        btnBack.alpha = 1.0f;
+    } completion:nil];
     
-    if (self.enableSkipButton) {
-        btnSkipCoach = [[UIButton alloc] initWithFrame:(CGRect){{lblContinueWidth, self.bounds.size.height - (2 * kShadowLayerOffset) - 30.0f}, {btnSkipWidth, 30.0f}}];
-        [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
-        [btnSkipCoach setTitle:@"Skip" forState:UIControlStateNormal];
-        btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:13.0f];
-        btnSkipCoach.alpha = 0.0f;
-        btnSkipCoach.tintColor = [UIColor whiteColor];
-        [self addSubview:btnSkipCoach];
-        [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
-            btnSkipCoach.alpha = 1.0f;
-        } completion:nil];
-    }
+    // Skip button
+    btnSkipCoach = [[UIButton alloc] initWithFrame:(CGRect){{skipButtonX, buttonY}, {skipButtonWidth, kButtonHeight}}];
+    [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
+    [btnSkipCoach setTitle:@"Skip" forState:UIControlStateNormal];
+    btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:13.0f];
+    btnSkipCoach.alpha = 0.0f;
+    [btnSkipCoach setTitleColor:[UIColor lightGrayColor] forState:UIControlStateNormal];
+    [self addSubview:btnSkipCoach];
+    [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
+        btnSkipCoach.alpha = 1.0f;
+    } completion:nil];
+    
+    // Next label
+    lblContinue = [[UILabel alloc] initWithFrame:(CGRect){{continueLabelX, buttonY}, {continueLabelWidth,kButtonHeight}}];
+    lblContinue.font = [UIFont boldSystemFontOfSize:13.0f];
+    lblContinue.textAlignment = NSTextAlignmentCenter;
+    lblContinue.text = @"Next";
+    lblContinue.alpha = 0.0f;
+    lblContinue.textColor = [UIColor whiteColor];
+    [self addSubview:lblContinue];
+    [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
+        lblContinue.alpha = 1.0f;
+    } completion:nil];
 }
 
 #pragma mark - Cleanup

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -328,13 +328,6 @@ static const CGFloat kShadowLayerOffset = 3.0f;
             btnBack.alpha = 1.0f;
         } completion:nil];
     }
-    else
-    {
-        [UIView animateWithDuration:self.animationDuration
-                         animations:^{
-                             [btnBack setFrame:backButtonFrame];
-                         }];
-    }
     
     // Skip button
     CGRect skipButtonFrame = CGRectMake(skipButtonX, buttonY, skipButtonWidth, kButtonHeight);
@@ -350,13 +343,6 @@ static const CGFloat kShadowLayerOffset = 3.0f;
         [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
             btnSkipCoach.alpha = 1.0f;
         } completion:nil];
-    }
-    else
-    {
-        [UIView animateWithDuration:self.animationDuration
-                         animations:^{
-                             [btnSkipCoach setFrame:skipButtonFrame];
-                         }];
     }
     
     // Next label
@@ -374,10 +360,15 @@ static const CGFloat kShadowLayerOffset = 3.0f;
             lblContinue.alpha = 1.0f;
         } completion:nil];
     }
-    else
+    
+    // Animate navigation buttons to their new positions
+    if (!CGRectEqualToRect(btnBack.frame, backButtonFrame) || !CGRectEqualToRect(btnSkipCoach.frame, skipButtonFrame)
+        || !CGRectEqualToRect(lblContinue.frame, continueLabelFrame))
     {
         [UIView animateWithDuration:self.animationDuration
                          animations:^{
+                             [btnBack setFrame:backButtonFrame];
+                             [btnSkipCoach setFrame:skipButtonFrame];
                              [lblContinue setFrame:continueLabelFrame];
                          }];
     }

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -13,7 +13,7 @@ static const CGFloat kAnimationDuration = 0.3f;
 static const CGFloat kCutoutRadius = 2.0f;
 static const CGFloat kMaxLblWidth = 300.0f;
 static const CGFloat kLblSpacing = 35.0f;
-static const CGFloat kButtonHeight = 60.0f;
+static const CGFloat kButtonHeight = 30.0f;
 static const CGFloat kButtonPadding = 10.0f;
 static const CGFloat kShadowLayerOffset = 3.0f;
 
@@ -305,7 +305,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     CGFloat backButtonX = kButtonPadding;
     CGFloat skipButtonX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth - skipButtonWidth - kButtonPadding;
     CGFloat continueLabelX = self.bounds.size.width - (2.0f * kShadowLayerOffset) - continueLabelWidth - kButtonPadding;
-    CGFloat buttonY = self.bounds.size.height - (2.0f * kShadowLayerOffset) - kButtonHeight;
+    CGFloat buttonY = self.bounds.size.height - (2.0f * kShadowLayerOffset) - kButtonHeight - kButtonPadding;
     
     // If the coach mark would overlap the navigation buttons, re-position the buttons to be above the coach mark
     // (Including the caption, which is likely above the coach mark in this case)

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -215,11 +215,44 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     // Coach mark definition
     NSDictionary *markDef = [self.coachMarks objectAtIndex:index];
     NSString *markCaption = [markDef objectForKey:@"caption"];
-    CGRect markRect = [[markDef objectForKey:@"rect"] CGRectValue];
     
     NSString *shape = @"other";
     if([[markDef allKeys] containsObject:@"shape"])
         shape = [markDef objectForKey:@"shape"];
+    
+    UIEdgeInsets markInsets = UIEdgeInsetsZero;
+    if ([[markDef allKeys] containsObject:@"insets"])
+        markInsets = [[markDef objectForKey:@"insets"] UIEdgeInsetsValue];
+    
+    // Type-check the object found for the "views" key
+    NSArray *markViewsArray = nil;
+    id viewOrArray = [markDef objectForKey:@"views"];
+    if ([viewOrArray isKindOfClass:[UIView class]])
+    {
+        markViewsArray = @[viewOrArray];
+    }
+    else if ([viewOrArray isKindOfClass:[NSArray class]])
+    {
+        markViewsArray = viewOrArray;
+    }
+    
+    // Construct the CGRect for the current coach mark from one or more UIViews.
+    // (The resulting CGRect is a CGRectUnion of all those views' bounds).
+    CGRect markRect = CGRectNull;
+    for (UIView *view in markViewsArray)
+    {
+        CGRect currentRect = UIEdgeInsetsInsetRect([view convertRect:view.bounds toView:self.superview], markInsets);
+        
+        if (CGRectEqualToRect(markRect, CGRectNull))
+        {
+            // First time around the loop
+            markRect = currentRect;
+        }
+        else
+        {
+            markRect = CGRectUnion(currentRect, markRect);
+        }
+    }
     
     // Delegate (coachMarksView:willNavigateTo:atIndex:)
     if ([self.delegate respondsToSelector:@selector(coachMarksView:willNavigateToIndex:)]) {

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -305,7 +305,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     CGFloat buttonY = self.bounds.size.height - (2.0f * kShadowLayerOffset) - kButtonHeight;
     
     // Back button
-    btnBack = [[UIButton alloc] initWithFrame:(CGRect){{backButtonX, buttonY}, {backButtonWidth, kButtonHeight}}];
+    btnBack = [[UIButton alloc] initWithFrame:CGRectMake(backButtonX, buttonY, backButtonWidth, kButtonHeight)];
     [btnBack addTarget:self action:@selector(goToPreviousCoachMark) forControlEvents:UIControlEventTouchUpInside];
     [btnBack setTitle:@"Back" forState:UIControlStateNormal];
     btnBack.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
@@ -316,7 +316,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     } completion:nil];
     
     // Skip button
-    btnSkipCoach = [[UIButton alloc] initWithFrame:(CGRect){{skipButtonX, buttonY}, {skipButtonWidth, kButtonHeight}}];
+    btnSkipCoach = [[UIButton alloc] initWithFrame:CGRectMake(skipButtonX, buttonY, skipButtonWidth, kButtonHeight)];
     [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
     [btnSkipCoach setTitle:@"Skip" forState:UIControlStateNormal];
     btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:15.0f];
@@ -328,7 +328,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     } completion:nil];
     
     // Next label
-    lblContinue = [[UILabel alloc] initWithFrame:(CGRect){{continueLabelX, buttonY}, {continueLabelWidth,kButtonHeight}}];
+    lblContinue = [[UILabel alloc] initWithFrame:CGRectMake(continueLabelX, buttonY, continueLabelWidth, kButtonHeight)];
     lblContinue.font = [UIFont boldSystemFontOfSize:15.0f];
     lblContinue.textAlignment = NSTextAlignmentCenter;
     lblContinue.text = @"Next";

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -179,6 +179,10 @@ static const CGFloat kShadowLayerOffset = 3.0f;
 
 #pragma mark - Navigation
 
+- (void)start {
+    [self startAtCoachMark:0];
+}
+
 - (void)startAtCoachMark:(NSUInteger)coachMarkIndex {
     // Fade in self
     self.alpha = 0.0f;

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -13,6 +13,7 @@ static const CGFloat kAnimationDuration = 0.3f;
 static const CGFloat kCutoutRadius = 2.0f;
 static const CGFloat kMaxLblWidth = 230.0f;
 static const CGFloat kLblSpacing = 35.0f;
+static const CGFloat kShadowLayerOffset = 3.0f;
 static const BOOL kEnableContinueLabel = YES;
 static const BOOL kEnableSkipButton = YES;
 
@@ -82,6 +83,18 @@ static const BOOL kEnableSkipButton = YES;
     [mask setFillRule:kCAFillRuleEvenOdd];
     [mask setFillColor:[[UIColor colorWithHue:0.0f saturation:0.0f brightness:0.0f alpha:0.9f] CGColor]];
     [self.layer addSublayer:mask];
+    CGRect layerBounds = self.layer.bounds;
+    layerBounds.origin = CGPointMake(-kShadowLayerOffset, -kShadowLayerOffset);
+    CGSize layerSize = layerBounds.size;
+    layerSize.height += (2 * kShadowLayerOffset);
+    layerSize.width += (2 * kShadowLayerOffset);
+    layerBounds.size = layerSize;
+    self.layer.bounds = layerBounds;
+    self.layer.masksToBounds = NO;
+    self.layer.shadowColor = _maskColor.CGColor;
+    self.layer.shadowOffset = CGSizeMake(0.0, 0.0);
+    self.layer.shadowOpacity = 1.0;
+    self.layer.shadowRadius = kShadowLayerOffset;
     
     // Capture touches
     UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(userDidTap:)];
@@ -219,7 +232,7 @@ static const BOOL kEnableSkipButton = YES;
     if (bottomY > self.bounds.size.height) {
         y = markRect.origin.y - self.lblSpacing - self.lblCaption.frame.size.height;
     }
-    CGFloat x = floorf((self.bounds.size.width - self.lblCaption.frame.size.width) / 2.0f);
+    CGFloat x = floorf((self.bounds.size.width - (2 * kShadowLayerOffset) - self.lblCaption.frame.size.width) / 2.0f);
     
     // Animate the caption label
     self.lblCaption.frame = (CGRect){{x, y}, self.lblCaption.frame.size};
@@ -238,13 +251,13 @@ static const BOOL kEnableSkipButton = YES;
     // Animate the cutout
     [self animateCutoutToRect:markRect withShape:shape];
     
-    CGFloat lblContinueWidth = self.enableSkipButton ? (70.0/100.0) * self.bounds.size.width : self.bounds.size.width;
+    CGFloat lblContinueWidth = self.enableSkipButton ? (70.0/100.0) * self.bounds.size.width - (2 * kShadowLayerOffset) : self.bounds.size.width - (2 * kShadowLayerOffset);
     CGFloat btnSkipWidth = self.bounds.size.width - lblContinueWidth;
     
     // Show continue lbl if first mark
     if (self.enableContinueLabel) {
         if (markIndex == 0) {
-            lblContinue = [[UILabel alloc] initWithFrame:(CGRect){{0, self.bounds.size.height - 30.0f}, {lblContinueWidth, 30.0f}}];
+            lblContinue = [[UILabel alloc] initWithFrame:(CGRect){{0, self.bounds.size.height - (2 * kShadowLayerOffset) - 30.0f}, {lblContinueWidth, 30.0f}}];
             lblContinue.font = [UIFont boldSystemFontOfSize:13.0f];
             lblContinue.textAlignment = NSTextAlignmentCenter;
             lblContinue.text = @"Tap to continue";
@@ -262,7 +275,7 @@ static const BOOL kEnableSkipButton = YES;
     }
     
     if (self.enableSkipButton) {
-        btnSkipCoach = [[UIButton alloc] initWithFrame:(CGRect){{lblContinueWidth, self.bounds.size.height - 30.0f}, {btnSkipWidth, 30.0f}}];
+        btnSkipCoach = [[UIButton alloc] initWithFrame:(CGRect){{lblContinueWidth, self.bounds.size.height - (2 * kShadowLayerOffset) - 30.0f}, {btnSkipWidth, 30.0f}}];
         [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
         [btnSkipCoach setTitle:@"Skip" forState:UIControlStateNormal];
         btnSkipCoach.titleLabel.font = [UIFont boldSystemFontOfSize:13.0f];

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -311,7 +311,18 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     // (Including the caption, which is likely above the coach mark in this case)
     if (CGRectGetMaxY(markRect) > buttonY)
     {
-        buttonY = CGRectGetMinY(self.lblCaption.frame) - (2.0f * kShadowLayerOffset) - kButtonHeight;
+        if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact)
+        {
+            // On iPhones in portrait orientation (horizontal size class compact) ensure the buttons have a little
+            // vertical space between their bottom edge and the top edge of the caption text to avoid crowding due to narrowness
+            buttonY = CGRectGetMinY(self.lblCaption.frame) - (2.0f * kShadowLayerOffset) - kButtonHeight;
+        }
+        else
+        {
+            // On iPhones in landscape or iPads in either orientation, we can ensure the bottom edge
+            // of the navigation buttons are exactly aligned with the top edge of the
+            buttonY = CGRectGetMinY(self.lblCaption.frame) - (2.0f * kShadowLayerOffset);
+        }
     }
     
     // Back button

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -11,7 +11,7 @@
 
 static const CGFloat kAnimationDuration = 0.3f;
 static const CGFloat kCutoutRadius = 2.0f;
-static const CGFloat kMaxLblWidth = 230.0f;
+static const CGFloat kMaxLblWidth = 300.0f;
 static const CGFloat kLblSpacing = 35.0f;
 static const CGFloat kShadowLayerOffset = 3.0f;
 static const BOOL kEnableContinueLabel = YES;

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -80,6 +80,9 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     [mask setFillRule:kCAFillRuleEvenOdd];
     [mask setFillColor:[[UIColor colorWithHue:0.0f saturation:0.0f brightness:0.0f alpha:0.9f] CGColor]];
     [self.layer addSublayer:mask];
+    
+    // Overdraw the layer so an overlap = kShadowLayer offset exists around all four edges of the layer
+    // (This allows the underlying shadow to extend to the edges of the transluscent coach marks view)
     CGRect layerBounds = self.layer.bounds;
     layerBounds.origin = CGPointMake(-kShadowLayerOffset, -kShadowLayerOffset);
     CGSize layerSize = layerBounds.size;

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -19,7 +19,6 @@ static const CGFloat kShadowLayerOffset = 3.0f;
 
 @implementation WSCoachMarksView {
     CAShapeLayer *mask;
-    NSUInteger markIndex;
     UIButton *btnBack;
     UILabel *lblContinue;
     UIButton *btnSkipCoach;
@@ -175,12 +174,12 @@ static const CGFloat kShadowLayerOffset = 3.0f;
 
 - (void)userDidTap:(UITapGestureRecognizer *)recognizer {
     // Go to the next coach mark
-    [self goToCoachMarkIndexed:(markIndex+1)];
+    [self goToCoachMarkIndexed:(self.markIndex+1)];
 }
 
 #pragma mark - Navigation
 
-- (void)start {
+- (void)startAtCoachMark:(NSUInteger)coachMarkIndex {
     // Fade in self
     self.alpha = 0.0f;
     self.hidden = NO;
@@ -190,14 +189,14 @@ static const CGFloat kShadowLayerOffset = 3.0f;
                      }
                      completion:^(BOOL finished) {
                          // Go to the first coach mark
-                         [self goToCoachMarkIndexed:0];
+                         [self goToCoachMarkIndexed:coachMarkIndex];
                      }];
 }
 
 - (void)goToPreviousCoachMark {
     // Go to the previous coach mark
-    if (markIndex > 0) {
-        [self goToCoachMarkIndexed:(markIndex-1)];
+    if (self.markIndex > 0) {
+        [self goToCoachMarkIndexed:(self.markIndex-1)];
     }
 }
 
@@ -213,7 +212,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     }
     
     // Current index
-    markIndex = index;
+    self.markIndex = index;
     
     // Coach mark definition
     NSDictionary *markDef = [self.coachMarks objectAtIndex:index];
@@ -264,7 +263,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     
     // Delegate (coachMarksView:willNavigateTo:atIndex:)
     if ([self.delegate respondsToSelector:@selector(coachMarksView:willNavigateToIndex:)]) {
-        [self.delegate coachMarksView:self willNavigateToIndex:markIndex];
+        [self.delegate coachMarksView:self willNavigateToIndex:self.markIndex];
     }
     
     // Calculate the caption position and size
@@ -287,7 +286,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     }];
     
     // If first mark, set the cutout to the center of first mark
-    if (markIndex == 0) {
+    if (self.markIndex == 0) {
         CGPoint center = CGPointMake(floorf(markRect.origin.x + (markRect.size.width / 2.0f)), floorf(markRect.origin.y + (markRect.size.height / 2.0f)));
         CGRect centerZero = (CGRect){center, CGSizeZero};
         [self setCutoutToRect:centerZero withShape:shape];
@@ -369,7 +368,7 @@ static const CGFloat kShadowLayerOffset = 3.0f;
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
     // Delegate (coachMarksView:didNavigateTo:atIndex:)
     if ([self.delegate respondsToSelector:@selector(coachMarksView:didNavigateToIndex:)]) {
-        [self.delegate coachMarksView:self didNavigateToIndex:markIndex];
+        [self.delegate coachMarksView:self didNavigateToIndex:self.markIndex];
     }
 }
 

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -238,6 +238,11 @@ static const CGFloat kShadowLayerOffset = 3.0f;
     {
         markViewsArray = viewOrArray;
     }
+    else
+    {
+        // Un-expected format or nil object
+        NSAssert(NO, @"Unexpected class for object for key 'views', or no object set. Please pass in one or more UIViews for the 'views' key instead.");
+    }
     
     // Construct the CGRect for the current coach mark from one or more UIViews.
     // (The resulting CGRect is a CGRectUnion of all those views' bounds).


### PR DESCRIPTION
This PR adds:
- A shadow to the view's `layer` which derives its color from `maskColor` which is set when instantiating an instance of `WSCoachMarksView`. This gives a much softer effect to coach marks, and as a nice side effect adds a shadow around the caption text and "Continue" and "Skip" buttons at the bottom of the view.
- The view's `layer` is now overdrawn to ensure the shadow is not obvious at the edge of the screen bounds. The origin and size of `self.layer` is modified accordingly.
- Positions and sizes of the internal `WSCoachMarksView` UI elements are adjusted accordingly with regard to the above point.
- Adds support for device orientation changes.
- Navigation buttons are re-positioned if they would overlap a coach mark.
